### PR TITLE
Added support for ArduinoOTA

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 data_dir = src/data
-env_default = openevse
+env_default = openevse_ota
 
 [common]
 version = -DBUILD_TAG=2.0.1
@@ -31,3 +31,11 @@ board = esp12e
 framework = arduino
 lib_deps = ${common.lib_deps}
 src_build_flags = ${common.version}
+
+[env:openevse_ota]
+platform = espressif8266
+board = esp12e
+framework = arduino
+lib_deps = ${common.lib_deps}
+src_build_flags = ${common.version} -DENABLE_OTA
+upload_port = openevse.local

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 data_dir = src/data
-env_default = openevse_ota
+env_default = openevse
 
 [common]
 version = -DBUILD_TAG=2.0.1

--- a/src/src.ino
+++ b/src/src.ino
@@ -37,6 +37,9 @@
 #include <ESP8266HTTPUpdateServer.h>  // upload update
 #include <DNSServer.h>                // Required for captive portal
 #include <PubSubClient.h>             // MQTT https://github.com/knolleary/pubsubclient PlatformIO lib: 89
+#ifdef ENABLE_OTA
+#include <ArduinoOTA.h>
+#endif
 
 #include "emonesp.h"
 #include "config.h"
@@ -75,8 +78,11 @@ void setup() {
   web_server_setup();
   delay(5000); //gives OpenEVSE time to finish self test on cold start
   handleRapiRead(); //Read all RAPI values
-  //  ota_setup();
-
+#ifdef ENABLE_OTA
+  // Start local OTA update server
+  ArduinoOTA.setHostname(esp_hostname);
+  ArduinoOTA.begin();
+#endif
 } // end setup
 
 // -------------------------------------------------------------------
@@ -86,6 +92,10 @@ void loop(){
 //ota_loop();
   web_server_loop();
   wifi_loop();
+#ifdef ENABLE_OTA
+  ArduinoOTA.handle();
+#endif
+
   if (mqtt_server !=0) mqtt_loop();
      
   

--- a/src/wifi.h
+++ b/src/wifi.h
@@ -24,6 +24,9 @@ extern String rssi;
 // Network state
 extern String ipaddress;
 
+// mDNS hostname
+extern const char *esp_hostname;
+
 extern void wifi_setup();
 extern void wifi_loop();
 extern void wifi_restart();


### PR DESCRIPTION
This adds (back) support for ArduinoOTA, which can be more convenient for development than serial upload. 

In my case my serial adapter does not support the higher speed of the default env and I am using a Huzzah board that does not have the reset/GPIO0 lines attached to the serial. 

The ArduinoOTA code is only included when building the openevse_ota environment so you have to flash this firmware first (via serial or HTTP upgrade) before the upload of the openevse_ota will work, but after that you just build/upload openevse_ota directly from PlatformIO (IDE).