### PR TITLE
Fixes V3

### DIFF
--- a/src/data/home.html
+++ b/src/data/home.html
@@ -415,6 +415,39 @@
             </form>
           </div>
           <div class="box380">
+            <h2>RAPI System Functions</h2>
+            <table>
+              <tr>
+                <th>Function</th>
+                <th>Description</th>
+              </tr>
+              <tr>
+                <td>$FB</td>
+                <td>LCD Backlight Color (0-7)</td>
+              </tr>
+              <tr>
+                <td>$FD</td>
+                <td>Disable EVSE</td>
+              </tr>
+              <tr>
+                <td>$FE</td>
+                <td>Enable EVSE</td>
+              </tr>
+              <tr>
+                <td>$FP</td>
+                <td>Output text at x y position text to LCD (x y text)</td>
+              </tr>
+              <tr>
+                <td>$FR</td>
+                <td>Reset EVSE</td>
+              </tr>
+              <tr>
+                <td>$FS</td>
+                <td>Put EVSE to sleep</td>
+              </tr>
+            </table>
+          </div>
+          <div class="box380">
             <h2>RAPI Get Commands</h2>
             <table>
               <tr>
@@ -551,39 +584,6 @@
               <tr>
                 <td>$SV</td>
                 <td>Enable (1) / Disable (0) vent required check</td>
-              </tr>
-            </table>
-          </div>
-          <div class="box380">
-            <h2>RAPI System Functions</h2>
-            <table>
-              <tr>
-                <th>Function</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td>$FB</td>
-                <td>LCD Backlight Color (0-7)</td>
-              </tr>
-              <tr>
-                <td>$FD</td>
-                <td>Disable EVSE</td>
-              </tr>
-              <tr>
-                <td>$FE</td>
-                <td>Enable EVSE</td>
-              </tr>
-              <tr>
-                <td>$FP</td>
-                <td>Output text at x y position text to LCD (x y text)</td>
-              </tr>
-              <tr>
-                <td>$FR</td>
-                <td>Reset EVSE</td>
-              </tr>
-              <tr>
-                <td>$FS</td>
-                <td>Put EVSE to sleep</td>
               </tr>
             </table>
           </div>

--- a/src/data/home.html
+++ b/src/data/home.html
@@ -217,19 +217,19 @@
               </tr>
               <tr data-bind="visible: '1' == config.service()">
                 <td>Level 1 Minimum:</td>
-                <td><span data-bind="text: config.l1min"></span></td>
+                <td><span data-bind="text: config.l1min() + ' A'"></span></td>
               </tr>
               <tr data-bind="visible: '1' == config.service()">
                 <td>Level 1 Maximum:</td>
-                <td><span data-bind="text: config.l1max"></span></td>
+                <td><span data-bind="text: config.l1max() + ' A'"></span></td>
               </tr>
               <tr data-bind="visible: '2' == config.service()">
                 <td>Level 2 Minimum:</td>
-                <td><span data-bind="text: config.l2min"></span></td>
+                <td><span data-bind="text: config.l2min() + ' A'"></span></td>
               </tr>
               <tr data-bind="visible: '2' == config.service()">
                 <td>Level 2 Maximum:</td>
-                <td><span data-bind="text: config.l2max"></span></td>
+                <td><span data-bind="text: config.l2max() + ' A'"></span></td>
               </tr>
               <tr>
                 <td>Sensor Scale:</td>
@@ -370,7 +370,7 @@
               </tr>
               <tr>
                 <td>Pilot:</td>
-                <td><span data-bind="text: rapi.pilot"></span></td>
+                <td><span data-bind="text: rapi.pilot() + ' A'"></span></td>
               </tr>
               <tr>
                 <td>Amps:</td>
@@ -378,15 +378,15 @@
               </tr>
               <tr>
                 <td>Temp1:</td>
-                <td><span data-bind="text: scaleString(rapi.temp1(), 10, 1) + ' C'"></span></td>
+                <td><span data-bind="text: scaleString(rapi.temp1(), 10, 1) + ' &deg;C'"></span></td>
               </tr>
               <tr>
                 <td>Temp2:</td>
-                <td><span data-bind="text: scaleString(rapi.temp2(), 10, 1) + ' C'"></span></td>
+                <td><span data-bind="text: scaleString(rapi.temp2(), 10, 1) + ' &deg;C'"></span></td>
               </tr>
               <tr>
                 <td>Temp3:</td>
-                <td><span data-bind="text: scaleString(rapi.temp3(), 10, 1) + ' C'"></span></td>
+                <td><span data-bind="text: scaleString(rapi.temp3(), 10, 1) + ' &deg;C'"></span></td>
               </tr>
             </table>
           </div>

--- a/src/data/home.html
+++ b/src/data/home.html
@@ -525,7 +525,7 @@
               </tr>
               <tr>
                 <td>$SK</td>
-                <td>Set accumulated kWh, integer</td>
+                <td>Set accumulated Wh, integer</td>
               </tr>
               <tr><td>$SL</td><td>Set service level (1/2/A)</td></tr>
               <tr>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -127,41 +127,46 @@ update_rapi_values() {
           comm_success++;
           String qrapi = rapiString.substring(rapiString.indexOf(' '));
           state = strtol(qrapi.c_str(), NULL, 16);
-          if (state == 1) {
-            estate = "Not_Connected";
-          }
-          if (state == 2) {
-            estate = "EV_Connected";
-          }
-          if (state == 3) {
-            estate = "Charging";
-          }
-          if (state == 4) {
-            estate = "Vent_Required";
-          }
-          if (state == 5) {
-            estate = "Diode_Check_Failed";
-          }
-          if (state == 6) {
-            estate = "GFCI_Fault";
-          }
-          if (state == 7) {
-            estate = "No_Earth_Ground";
-          }
-          if (state == 8) {
-            estate = "Stuck_Relay";
-          }
-          if (state == 9) {
-            estate = "GFCI_Self_Test_Failed";
-          }
-          if (state == 10) {
-            estate = "Over_Temperature";
-          }
-          if (state == 254) {
-            estate = "Sleeping";
-          }
-          if (state == 255) {
-            estate = "Disabled";
+          switch (state) {
+            case 1:
+              estate = "Not Connected";
+              break;
+            case 2:
+              estate = "EV Connected";
+              break;
+            case 3:
+              estate = "Charging";
+              break;
+            case 4:
+              estate = "Vent Required";
+              break;
+            case 5:
+              estate = "Diode Check Failed";
+              break;
+            case 6:
+              estate = "GFCI Fault";
+              break;
+            case 7:
+              estate = "No Earth Ground";
+              break;
+            case 8:
+              estate = "Stuck Relay";
+              break;
+            case 9:
+              estate = "GFCI Self Test Failed";
+              break;
+            case 10:
+              estate = "Over Temperature";
+              break;
+            case 254:
+              estate = "Sleeping";
+              break;
+            case 255:
+              estate = "Disabled";
+              break;
+            default:
+              estate = "Invalid";
+              break;
           }
         }
       }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -111,8 +111,10 @@ update_rapi_values() {
         String rapiString = Serial.readStringUntil('\r');
         if (rapiString.startsWith("$OK ")) {
           comm_success++;
+          int firstRapiCmd = rapiString.indexOf(' ');
+          int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
           String qrapi;
-          qrapi = rapiString.substring(rapiString.indexOf(' '));
+          qrapi = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
           pilot = qrapi.toInt();
         }
       }
@@ -174,11 +176,13 @@ update_rapi_values() {
         String rapiString = Serial.readStringUntil('\r');
         if (rapiString.startsWith("$OK")) {
           comm_success++;
+          int firstRapiCmd = rapiString.indexOf(' ');
+          int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
           String qrapi;
-          qrapi = rapiString.substring(rapiString.indexOf(' '));
+          qrapi = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
           amp = qrapi.toInt();
           String qrapi1;
-          qrapi1 = rapiString.substring(rapiString.lastIndexOf(' '));
+          qrapi1 = rapiString.substring(secondRapiCmd + 1);
           volt = qrapi1.toInt();
         }
       }
@@ -191,15 +195,17 @@ update_rapi_values() {
         String rapiString = Serial.readStringUntil('\r');
         if (rapiString.startsWith("$OK")) {
           comm_success++;
+          int firstRapiCmd = rapiString.indexOf(' ');
+          int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
+          int thirdRapiCmd = rapiString.indexOf(' ', secondRapiCmd + 1);
           String qrapi;
-          qrapi = rapiString.substring(rapiString.indexOf(' '));
+          qrapi = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
           temp1 = qrapi.toInt();
           String qrapi1;
-          int firstRapiCmd = rapiString.indexOf(' ');
-          qrapi1 = rapiString.substring(rapiString.indexOf(' ', firstRapiCmd + 1));
+          qrapi1 = rapiString.substring(secondRapiCmd + 1, thirdRapiCmd);
           temp2 = qrapi1.toInt();
           String qrapi2;
-          qrapi2 = rapiString.substring(rapiString.lastIndexOf(' '));
+          qrapi2 = rapiString.substring(thirdRapiCmd + 1);
           temp3 = qrapi2.toInt();
         }
       }
@@ -214,8 +220,8 @@ update_rapi_values() {
           comm_success++;
           int firstRapiCmd = rapiString.indexOf(' ');
           int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
-          wattsec = rapiString.substring(firstRapiCmd, secondRapiCmd);
-          watthour_total = rapiString.substring(secondRapiCmd);
+          wattsec = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
+          watthour_total = rapiString.substring(secondRapiCmd + 1);
         }
       }
     }
@@ -230,9 +236,9 @@ update_rapi_values() {
           int firstRapiCmd = rapiString.indexOf(' ');
           int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
           int thirdRapiCmd = rapiString.indexOf(' ', secondRapiCmd + 1);
-          gfci_count = rapiString.substring(firstRapiCmd, secondRapiCmd);
-          nognd_count = rapiString.substring(secondRapiCmd, thirdRapiCmd);
-          stuck_count = rapiString.substring(thirdRapiCmd);
+          gfci_count = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
+          nognd_count = rapiString.substring(secondRapiCmd + 1, thirdRapiCmd);
+          stuck_count = rapiString.substring(thirdRapiCmd + 1);
         }
       }
       rapi_command = 0;         //Last RAPI command
@@ -260,8 +266,8 @@ handleRapiRead() {
       comm_success++;
       int firstRapiCmd = rapiString.indexOf(' ');
       int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
-      firmware = rapiString.substring(firstRapiCmd, secondRapiCmd);
-      protocol = rapiString.substring(secondRapiCmd);
+      firmware = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
+      protocol = rapiString.substring(secondRapiCmd + 1);
     }
   }
   Serial.println("$GA*AC");
@@ -273,8 +279,8 @@ handleRapiRead() {
       comm_success++;
       int firstRapiCmd = rapiString.indexOf(' ');
       int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
-      current_scale = rapiString.substring(firstRapiCmd, secondRapiCmd);
-      current_offset = rapiString.substring(secondRapiCmd);
+      current_scale = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
+      current_offset = rapiString.substring(secondRapiCmd + 1);
     }
   }
   Serial.println("$GH");
@@ -285,7 +291,7 @@ handleRapiRead() {
     if (rapiString.startsWith("$OK")) {
       comm_success++;
       int firstRapiCmd = rapiString.indexOf(' ');
-      kwh_limit = rapiString.substring(firstRapiCmd);
+      kwh_limit = rapiString.substring(firstRapiCmd + 1);
     }
   }
   Serial.println("$G3");
@@ -296,7 +302,7 @@ handleRapiRead() {
     if (rapiString.startsWith("$OK")) {
       comm_success++;
       int firstRapiCmd = rapiString.indexOf(' ');
-      time_limit = rapiString.substring(firstRapiCmd);
+      time_limit = rapiString.substring(firstRapiCmd + 1);
     }
   }
   Serial.println("$GE*B0");
@@ -306,10 +312,12 @@ handleRapiRead() {
     String rapiString = Serial.readStringUntil('\r');
     if (rapiString.startsWith("$OK ")) {
       comm_success++;
+      int firstRapiCmd = rapiString.indexOf(' ');
+      int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
       String qrapi;
-      qrapi = rapiString.substring(rapiString.indexOf(' '));
+      qrapi = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
       pilot = qrapi.toInt();
-      String flag = rapiString.substring(rapiString.lastIndexOf(' '));
+      String flag = rapiString.substring(secondRapiCmd + 1);
       long flags = strtol(flag.c_str(), NULL, 16);
       service = bitRead(flags, 0) + 1;
       diode_ck = bitRead(flags, 1);
@@ -334,11 +342,11 @@ handleRapiRead() {
       int firstRapiCmd = rapiString.indexOf(' ');
       int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
       if (service == 1) {
-        current_l1min = rapiString.substring(firstRapiCmd, secondRapiCmd);
-        current_l1max = rapiString.substring(secondRapiCmd);
+        current_l1min = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
+        current_l1max = rapiString.substring(secondRapiCmd + 1);
       } else {
-        current_l2min = rapiString.substring(firstRapiCmd, secondRapiCmd);
-        current_l2max = rapiString.substring(secondRapiCmd);
+        current_l2min = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
+        current_l2max = rapiString.substring(secondRapiCmd + 1);
       }
     }
   }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -16,12 +16,12 @@ int rapi_command_sent = 0;
 int comm_Delay = 1000;          //Delay between each command and read or write
 unsigned long comm_Timer = 0;   //Timer for Comm requests
 
-int amp = 0;                    //OpenEVSE Current Sensor
-int volt = 0;                   //Not currently in used
-int temp1 = 0;                  //Sensor DS3232 Ambient
-int temp2 = 0;                  //Sensor MCP9808 Ambient
-int temp3 = 0;                  //Sensor TMP007 Infared
-int pilot = 0;                  //OpenEVSE Pilot Setting
+String amp = "0";                    //OpenEVSE Current Sensor
+String volt = "0";                   //Not currently in used
+String temp1 = "0";                  //Sensor DS3232 Ambient
+String temp2 = "0";                  //Sensor MCP9808 Ambient
+String temp3 = "0";                  //Sensor TMP007 Infared
+String pilot = "0";                  //OpenEVSE Pilot Setting
 long state = 0;                 //OpenEVSE State
 String estate = "Unknown";      // Common name for State
 
@@ -70,11 +70,11 @@ create_rapi_json() {
   url = e_url;
   data = "";
   url += String(emoncms_node) + "&json={";
-  data += "amp:" + String(amp) + ",";
-  data += "temp1:" + String(temp1) + ",";
-  data += "temp2:" + String(temp2) + ",";
-  data += "temp3:" + String(temp3) + ",";
-  data += "pilot:" + String(pilot) + ",";
+  data += "amp:" + amp + ",";
+  data += "temp1:" + temp1 + ",";
+  data += "temp2:" + temp2 + ",";
+  data += "temp3:" + temp3 + ",";
+  data += "pilot:" + pilot + ",";
   data += "state:" + String(state);
   url += data;
   if (emoncms_server == "data.openevse.com/emoncms") {
@@ -113,9 +113,7 @@ update_rapi_values() {
           comm_success++;
           int firstRapiCmd = rapiString.indexOf(' ');
           int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
-          String qrapi;
-          qrapi = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
-          pilot = qrapi.toInt();
+          pilot = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
         }
       }
     }
@@ -178,12 +176,8 @@ update_rapi_values() {
           comm_success++;
           int firstRapiCmd = rapiString.indexOf(' ');
           int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
-          String qrapi;
-          qrapi = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
-          amp = qrapi.toInt();
-          String qrapi1;
-          qrapi1 = rapiString.substring(secondRapiCmd + 1);
-          volt = qrapi1.toInt();
+          amp = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
+          volt = rapiString.substring(secondRapiCmd + 1);
         }
       }
     }
@@ -198,15 +192,9 @@ update_rapi_values() {
           int firstRapiCmd = rapiString.indexOf(' ');
           int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
           int thirdRapiCmd = rapiString.indexOf(' ', secondRapiCmd + 1);
-          String qrapi;
-          qrapi = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
-          temp1 = qrapi.toInt();
-          String qrapi1;
-          qrapi1 = rapiString.substring(secondRapiCmd + 1, thirdRapiCmd);
-          temp2 = qrapi1.toInt();
-          String qrapi2;
-          qrapi2 = rapiString.substring(thirdRapiCmd + 1);
-          temp3 = qrapi2.toInt();
+          temp1 = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
+          temp2 = rapiString.substring(secondRapiCmd + 1, thirdRapiCmd);
+          temp3 = rapiString.substring(thirdRapiCmd + 1);
         }
       }
     }
@@ -314,9 +302,7 @@ handleRapiRead() {
       comm_success++;
       int firstRapiCmd = rapiString.indexOf(' ');
       int secondRapiCmd = rapiString.indexOf(' ', firstRapiCmd + 1);
-      String qrapi;
-      qrapi = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
-      pilot = qrapi.toInt();
+      pilot = rapiString.substring(firstRapiCmd + 1, secondRapiCmd);
       String flag = rapiString.substring(secondRapiCmd + 1);
       long flags = strtol(flag.c_str(), NULL, 16);
       service = bitRead(flags, 0) + 1;

--- a/src/input.h
+++ b/src/input.h
@@ -11,13 +11,13 @@ extern int espfree;
 
 extern int commDelay;
 
-extern int amp; //OpenEVSE Current Sensor
-extern int volt; //Not currently in used
-extern int temp1; //Sensor DS3232 Ambient
-extern int temp2; //Sensor MCP9808 Ambient
-extern int temp3; //Sensor TMP007 Infared
-extern int pilot; //OpenEVSE Pilot Setting
-extern long state; //OpenEVSE State
+extern String amp;    // OpenEVSE Current Sensor
+extern String volt;   // Not currently in used
+extern String temp1;  // Sensor DS3232 Ambient
+extern String temp2;  // Sensor MCP9808 Ambient
+extern String temp3;  // Sensor TMP007 Infared
+extern String pilot;  // OpenEVSE Pilot Setting
+extern long state;    // OpenEVSE State
 extern String estate; // Common name for State
 
 //Defaults OpenEVSE Settings

--- a/src/src.ino
+++ b/src/src.ino
@@ -38,7 +38,7 @@
 
 unsigned long Timer1; // Timer for events once every 30 seconds
 unsigned long Timer2; // Timer for events once every 1 Minute
-unsigned long Timer3; // Timer for events once every 5 seconds
+unsigned long Timer3; // Timer for events once every 2 seconds
 
 // -------------------------------------------------------------------
 // SETUP
@@ -90,9 +90,9 @@ loop() {
 
   if (wifi_mode == WIFI_MODE_STA || wifi_mode == WIFI_MODE_AP_AND_STA) {
 // -------------------------------------------------------------------
-// Do these things once every 5s
+// Do these things once every 2s
 // -------------------------------------------------------------------
-    if ((millis() - Timer3) >= 5000) {
+    if ((millis() - Timer3) >= 2000) {
       update_rapi_values();
       Timer3 = millis();
     }

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -355,7 +355,6 @@ handleConfig(AsyncWebServerRequest *request) {
   s += "\"www_username\":\"" + www_username + "\"";
   //s += "\"www_password\":\""+www_password+"\","; security risk: DONT RETURN PASSWORDS
   s += "}";
-  s.replace(" ", "");
 
   response->setCode(200);
   response->print(s);
@@ -388,11 +387,10 @@ handleUpdate(AsyncWebServerRequest *request) {
   s += "\"temp1\":\"" + temp1 + "\",";
   s += "\"temp2\":\"" + temp2 + "\",";
   s += "\"temp3\":\"" + temp3 + "\",";
-  s += "\"estate\":\"" + String(estate) + "\",";
+  s += "\"estate\":\"" + estate + "\",";
   s += "\"wattsec\":\"" + wattsec + "\",";
   s += "\"watthour\":\"" + watthour_total + "\"";
   s += "}";
-  s.replace(" ", "");
 
   response->setCode(200);
   response->print(s);

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -383,11 +383,11 @@ handleUpdate(AsyncWebServerRequest *request) {
   s += "\"packets_sent\":\"" + String(packets_sent) + "\",";
   s += "\"packets_success\":\"" + String(packets_success) + "\",";
 #endif
-  s += "\"amp\":\"" + String(amp) + "\",";
-  s += "\"pilot\":\"" + String(pilot) + "\",";
-  s += "\"temp1\":\"" + String(temp1) + "\",";
-  s += "\"temp2\":\"" + String(temp2) + "\",";
-  s += "\"temp3\":\"" + String(temp3) + "\",";
+  s += "\"amp\":\"" + amp + "\",";
+  s += "\"pilot\":\"" + pilot + "\",";
+  s += "\"temp1\":\"" + temp1 + "\",";
+  s += "\"temp2\":\"" + temp2 + "\",";
+  s += "\"temp3\":\"" + temp3 + "\",";
   s += "\"estate\":\"" + String(estate) + "\",";
   s += "\"wattsec\":\"" + wattsec + "\",";
   s += "\"watthour\":\"" + watthour_total + "\"";

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -99,6 +99,11 @@ startAP() {
   Serial.print("$FP 0 1 ");
   Serial.println(tmpStr);
   ipaddress = tmpStr;
+  Serial.flush(); // Clear serial output buffer
+  delay(100);
+  // Clear serial input buffer for RAPI packet accounting
+  while (Serial.available())
+    Serial.read(); 
 }
 
 // -------------------------------------------------------------------
@@ -168,6 +173,11 @@ startClient() {
     // Copy the connected network and ipaddress to global strings for use in status request
     connected_network = esid;
     ipaddress = tmpStr;
+    Serial.flush(); // Clear serial output buffer
+    delay(100);
+    // Clear serial input buffer for RAPI packet accounting
+    while (Serial.available())
+      Serial.read(); 
   }
 }
 


### PR DESCRIPTION
Another handful of odds and ends.  This is running in the garage, but please do test.

This changes the RAPI timer loop back to 2s so that all values will be updated within the default emoncms update window (30s).

The most "interesting" thing is a cleanup of the RAPI token parsing - yes, this will/should all go away to a helper/class at some point, but for now this change makes it all consistent and eliminates spaces that end up in the tokens.  This has a cascade effect which lets us get rid of a bunch of to/from int conversions, space removals from JSON strings, and the like.  Ultimately it means that the system state can be displayed without underlines \o/.  It should make replacement with a RAPI class simpler as well.

Other changes:

- Fix a bug where when we start up, we claim to have processed more RAPI packets than we have sent.
- Add a few more "A" (amp) units to the status page, and adds a fancy degree sign to the Celsius temp displays (too much?)  ;)
- Rearrange the RAPI tab to fit better after @jeremypoulter 's changes
- Re-fix $SK units on rapi page help
<img width="650" alt="image" src="https://cloud.githubusercontent.com/assets/427124/26183589/5fe2d894-3b45-11e7-814c-13ab5b35b861.png">

