### PR TITLE
Added defaults to the config.cpp

### DIFF
--- a/src/emonesp.h
+++ b/src/emonesp.h
@@ -11,5 +11,6 @@
 #define DEBUG Serial
 #endif
 
+#include "debug.h"
 
 #endif // _EMONESP_H

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -10,7 +10,6 @@
 #include "input.h"
 #include "emoncms.h"
 #include "divert.h"
-#include "debug.h"
 
 AsyncWebServer server(80);          //Create class for Web server
 


### PR DESCRIPTION
Resolves #19

This includes adding a very simple checksum to the last byte of each string. This should help with flashing on a new board with unknown content in the EEPROM. **Note**: This will invalidate existing setting so updating will essentially factory reset and also going back to an older build after using a build with these changes will result in a 'random' char at the end of each saved config.

Also include debug.h from emonesp.h just to make life easier.