### PR TITLE
Force a reconnect immediately when MQTT setting changed.

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -34,22 +34,22 @@ mqttmsg_callback(char *topic, byte * payload, unsigned int length) {
   }
   DEBUG.println();
 
-  
+
   // If MQTT message is solar PV
   if (topic_string = mqtt_solar){
     solar = int(payload);
   }
-  
+
   // If MQTT message is grid import / export
   if (topic_string = mqtt_grid_ie){
     grid_ie = int(payload);
   }
-  
+
   // If MQTT message to set divert mode is received
   if (topic_string = mqtt_topic + "divertmode"){
     divertmode_update(int(payload));
   }
-  
+
   // If MQTT message is RAPI command
   // Detect if MQTT message is a RAPI command e.g to set 13A <base-topic>/rapi/$SC 13
   // Locate '$' character in the MQTT message to identify RAPI command
@@ -110,7 +110,7 @@ mqtt_connect() {
     }
     mqtt_sub_topic = mqtt_topic + "/divertmode";      // MQTT Topic to change divert mode
     mqttclient.subscribe(mqtt_sub_topic.c_str());
-    
+
   } else {
     DEBUG.print("MQTT failed: ");
     DEBUG.println(mqttclient.state());
@@ -197,6 +197,7 @@ mqtt_restart() {
   if (mqttclient.connected()) {
     mqttclient.disconnect();
   }
+  lastMqttReconnectAttempt = 0;
 }
 
 boolean


### PR DESCRIPTION
Previously if MQTT had failed to connect the reconnection would not take place until the next connection attempt which could be up to 10s.