### PR TITLE
Hostname related changes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -37,5 +37,6 @@ platform = espressif8266
 board = esp12e
 framework = arduino
 lib_deps = ${common.lib_deps}
-src_build_flags = ${common.version} -DENABLE_OTA -DWIFI_LED=0 -DENABLE_DEBUG
-upload_port = openevse.local
+# set ESP_WIFI_HOSTNAME to the desired hostname in your environment
+src_build_flags = ${common.version} -DENABLE_OTA -DWIFI_LED=0 -DENABLE_DEBUG -DWIFI_HOSTNAME=${env.ESP_WIFI_HOSTNAME}
+upload_port = ${env.ESP_WIFI_HOSTNAME}.local

--- a/src/debug.h
+++ b/src/debug.h
@@ -4,9 +4,6 @@
 //#define DEBUG
 //#define DEBUG_PORT Serial
 
-#define TEXTIFY(A) #A
-#define ESCAPEQUOTE(A) TEXTIFY(A)
-
 #ifdef ENABLE_DEBUG
 
 #ifndef DEBUG_PORT

--- a/src/emonesp.h
+++ b/src/emonesp.h
@@ -16,4 +16,7 @@
 
 #include "debug.h"
 
+#define TEXTIFY(A) #A
+#define ESCAPEQUOTE(A) TEXTIFY(A)
+
 #endif // _EMONESP_H

--- a/src/src.ino
+++ b/src/src.ino
@@ -56,7 +56,9 @@ setup() {
 #endif
 
   DEBUG.println();
-  DEBUG.print("OpenEVSE WiFI ");
+  DEBUG.print("OpenEVSE WiFi ");
+  DEBUG.print(esp_hostname);
+  DEBUG.print(" ");
   DEBUG.println(ESP.getChipId());
   DEBUG.println("Firmware: " + currentfirmware);
 

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -22,8 +22,6 @@ unsigned long systemRestartTime = 0;
 unsigned long systemRebootTime = 0;
 
 // Get running firmware version from build tag environment variable
-#define TEXTIFY(A) #A
-#define ESCAPEQUOTE(A) TEXTIFY(A)
 String currentfirmware = ESCAPEQUOTE(BUILD_TAG);
 
 // -------------------------------------------------------------------

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -30,7 +30,7 @@ String currentfirmware = ESCAPEQUOTE(BUILD_TAG);
 bool requestPreProcess(AsyncWebServerRequest *request, AsyncResponseStream *&response, const char *contentType = "application/json")
 {
   if(www_username!="" && !request->authenticate(www_username.c_str(), www_password.c_str())) {
-    request->requestAuthentication();
+    request->requestAuthentication(esp_hostname);
     return false;
 }
 
@@ -52,7 +52,7 @@ handleHome(AsyncWebServerRequest *request) {
       && !request->authenticate(www_username.c_str(),
                               www_password.c_str())
       && wifi_mode == WIFI_MODE_STA) {
-    return request->requestAuthentication();
+    return request->requestAuthentication(esp_hostname);
   }
 
   if (SPIFFS.exists("/home.htm")) {

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -15,9 +15,6 @@ const char *softAP_password = "openevse";
 IPAddress apIP(192, 168, 4, 1);
 IPAddress netMsk(255, 255, 255, 0);
 
-// hostname for mDNS. Should work at least on windows. Try http://openevse or http://openevse.local
-const char *esp_hostname = "openevse";
-
 // Wifi Network Strings
 String connected_network = "";
 String status_string = "";
@@ -25,6 +22,13 @@ String ipaddress = "";
 
 unsigned long Timer;
 String st, rssi;
+
+#ifndef WIFI_HOSTNAME
+#define WIFI_HOSTNAME openevse
+#endif
+
+// hostname for mDNS. Should work at least on windows. Try http://openevse or http://openevse.local
+const char *esp_hostname = ESCAPEQUOTE(WIFI_HOSTNAME);
 
 #ifdef WIFI_LED
 #ifndef WIFI_LED_ON_STATE
@@ -41,7 +45,7 @@ String st, rssi;
 
 int wifiLedState = !WIFI_LED_ON_STATE;
 unsigned long wifiLedTimeOut = millis();
-#endif
+#endif // WIFI_LED
 
 // -------------------------------------------------------------------
 int wifi_mode = WIFI_MODE_STA;
@@ -103,7 +107,7 @@ startAP() {
   delay(100);
   // Clear serial input buffer for RAPI packet accounting
   while (Serial.available())
-    Serial.read(); 
+    Serial.read();
 }
 
 // -------------------------------------------------------------------
@@ -115,7 +119,7 @@ startClient() {
   DEBUG.println(esid.c_str());
   // DEBUG.print(" epass:");
   // DEBUG.println(epass.c_str());
-  WiFi.hostname("openevse");
+  WiFi.hostname(esp_hostname);
   WiFi.begin(esid.c_str(), epass.c_str());
 
   delay(50);
@@ -177,7 +181,7 @@ startClient() {
     delay(100);
     // Clear serial input buffer for RAPI packet accounting
     while (Serial.available())
-      Serial.read(); 
+      Serial.read();
   }
 }
 


### PR DESCRIPTION
I have one openevse in "production" and one on the desk; having the OTA target push to "openevse" is ... dangerous when there are 2 hosts running with the same name.

The first commit allows the hostname to be set during build time via `-DHOSTNAME`, and changes it name to "openevse-ota" (we could call it -devel, or whatever you like?)

The second commit changes the authentication realm from "asyncesp" to whatever the wifi hostname has been set to (openevse, openevse-ota, etc), for consistency.

(Eventually an option on a configuration tab to choose the hostname might be nice for anyone with more than one openevse in production)