### PR TITLE
Config fixes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -37,5 +37,5 @@ platform = espressif8266
 board = esp12e
 framework = arduino
 lib_deps = ${common.lib_deps}
-src_build_flags = ${common.version} -DENABLE_OTA -DWIFI_LED=0 -DENABLE_DEBUG
+src_build_flags = ${common.version} -DENABLE_OTA -DWIFI_LED=0 -DENABLE_DEBUG -DDEBUG_PORT=Serial
 upload_port = openevse.local

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -44,7 +44,7 @@ String ohm = "";
 #define EEPROM_WWW_USER_SIZE          16
 #define EEPROM_WWW_PASS_SIZE          16
 #define EEPROM_OHM_KEY_SIZE           8
-#define EEPROM_SIZE                   512
+#define EEPROM_SIZE                   4096
 
 #define EEPROM_ESID_START             0
 #define EEPROM_ESID_END               (EEPROM_ESID_START + EEPROM_ESID_SIZE)
@@ -77,6 +77,10 @@ String ohm = "";
 #define EEPROM_OHM_KEY_START          EEPROM_WWW_PASS_END
 #define EEPROM_OHM_KEY_END            (EEPROM_OHM_KEY_START + EEPROM_OHM_KEY_SIZE)
 
+#if EEPROM_OHM_KEY_END > EEPROM_SIZE
+#error EEPROM_SIZE too small
+#endif
+
 #define CHECKSUM_SEED 128
 
 // -------------------------------------------------------------------
@@ -107,7 +111,7 @@ EEPROM_read_string(int start, int count, String & val, String defaultVal = "") {
 
   // Check the checksum
   byte c = EEPROM.read(start + (count - 1));
-  DBUGF("Got '%s'  %d == %d", val.c_str(), c, checksum);
+  DBUGF("Got '%s' %d == %d @ %d:%d", val.c_str(), c, checksum, start, count);
   if(c != checksum) {
     DBUGF("Using default '%s'", defaultVal.c_str());
     val = defaultVal;
@@ -126,6 +130,7 @@ EEPROM_write_string(int start, int count, String val) {
     }
   }
   EEPROM.write(start + (count - 1), checksum);
+  DBUGF("Saved '%s' %d @ %d:%d", val.c_str(), checksum, start, count);
 }
 
 // -------------------------------------------------------------------

--- a/src/src.ino
+++ b/src/src.ino
@@ -67,6 +67,14 @@ setup() {
   // Start local OTA update server
   ArduinoOTA.setHostname(esp_hostname);
   ArduinoOTA.begin();
+#ifdef WIFI_LED
+  ArduinoOTA.onProgress([](unsigned int pos, unsigned int size) {
+    DBUGF("Upgrade %d/%d", pos, size);
+    static int state = LOW;
+    state = !state;
+    digitalWrite(WIFI_LED, state);
+  });
+#endif
 #endif
 } // end setup
 
@@ -75,6 +83,7 @@ setup() {
 // -------------------------------------------------------------------
 void
 loop() {
+  unsigned long loopStart = millis();
 
   web_server_loop();
   wifi_loop();
@@ -124,4 +133,9 @@ loop() {
     }
 
   } // end WiFi connected
+
+  unsigned long loopTime = millis() - loopStart;
+  if(loopTime > 10) {
+    DBUGF("Slow loop %dms", loopTime);
+  }
 } // end loop


### PR DESCRIPTION
The config had gone over 512 bytes so the web auth settings and Ohm key where not being saved. The ESP8266 has 4096 bytes of 'EEPROM' so just changed to use the full size.

The 'EEPROM' is however duplicated in RAM so may need to consider reducing this number if memory starts to get a bit tight.