### PR TITLE
Don't push any LCD messages until the OpenEVSE has started

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -9,6 +9,7 @@
 #include "mqtt.h"
 #include "web_server.h"
 #include "wifi.h"
+#include "openevse.h"
 
 #include "RapiSender.h"
 
@@ -26,13 +27,13 @@ int espfree = 0;
 
 int rapi_command = 1;
 
-long amp = 0;                          // OpenEVSE Current Sensor
-long volt = 0;                         // Not currently in used
-long temp1 = 0;                        // Sensor DS3232 Ambient
-long temp2 = 0;                        // Sensor MCP9808 Ambient
-long temp3 = 0;                        // Sensor TMP007 Infared
-long pilot = 0;                        // OpenEVSE Pilot Setting
-long state = 0;                       // OpenEVSE State
+long amp = 0;                         // OpenEVSE Current Sensor
+long volt = 0;                        // Not currently in used
+long temp1 = 0;                       // Sensor DS3232 Ambient
+long temp2 = 0;                       // Sensor MCP9808 Ambient
+long temp3 = 0;                       // Sensor TMP007 Infared
+long pilot = 0;                       // OpenEVSE Pilot Setting
+long state = OPENEVSE_STATE_STARTING; // OpenEVSE State
 long elapsed = 0;                     // Elapsed time (only valid if charging)
 #ifdef ENABLE_LEGACY_API
 String estate = "Unknown"; // Common name for State

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -1,6 +1,8 @@
 #include "emonesp.h"
 #include "lcd.h"
 #include "RapiSender.h"
+#include "openevse.h"
+#include "input.h"
 
 #define LCD_MAX_LEN 16
 
@@ -79,6 +81,11 @@ void lcd_display(const char *msg, int x, int y, int time, uint32_t flags)
 
 void lcd_loop()
 {
+  // If the OpenEVSE has not started don't do anything
+  if(OPENEVSE_STATE_STARTING == state) {
+    return;
+  }
+
   while(millis() >= nextTime)
   {
     if(head)

--- a/src/src.ino
+++ b/src/src.ino
@@ -88,6 +88,20 @@ void setup() {
 
   rapiSender.setOnEvent(on_rapi_event);
   rapiSender.enableSequenceId(0);
+
+  // Check state the OpenEVSE is in.
+  if (0 == rapiSender.sendCmd("$GS"))
+  {
+    if(rapiSender.getTokenCnt() >= 3)
+    {
+      const char *val = rapiSender.getToken(1);
+      DBUGVAR(val);
+      state = strtol(val, NULL, 10);
+      DBUGVAR(state);
+    }
+  } else {
+    DBUGLN("OpenEVSE not responding or not connected");
+  }
 } // end setup
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
This change stops OpenEVSE WiFi from pushing any LCD updates until the OpenEVSE has started up (state != 0). 

See this [demo](https://youtu.be/AhnaAyhI1UE) (ignore the "MQTT connected" text, this is pushed via a persistent RAPI command on my MQTT broker)