### PR TITLE
'Fix' for auth crashing the ESP

### DIFF
--- a/src/web_server_static.cpp
+++ b/src/web_server_static.cpp
@@ -72,8 +72,10 @@ void StaticFileWebHandler::handleRequest(AsyncWebServerRequest *request)
   dumpRequest(request);
 
   // Are we authenticated
-  if(wifi_mode_is_sta() && www_username!="" &&
-    false == request->authenticate(www_username.c_str(), www_password.c_str())) {
+  if(wifi_mode_is_sta() &&
+     _username != "" && _password != "" &&
+     false == request->authenticate(_username.c_str(), _password.c_str()))
+  {
     request->requestAuthentication(esp_hostname);
     return;
   }


### PR DESCRIPTION
I use the term fix very loosely. What this actually does is allow the StaticFileWebHandler to have the authentication separately configured, as with the other handlers, and then not configure authentication.

The effect of this is that only the dynamic content asks for authentication. This should be ok but the underlying bug in the new StaticFileWebHandler is still there.

Fixes #101 