### PR TITLE
Update TimeViewModel.js

### DIFF
--- a/src/html/view_models/TimeViewModel.js
+++ b/src/html/view_models/TimeViewModel.js
@@ -66,7 +66,7 @@ function TimeViewModel(openevse)
       return "0:00:00";
     }
     var dt = self.elapsedNow();
-    return addZero(dt.getHours())+":"+addZero(dt.getMinutes())+":"+addZero(dt.getSeconds());
+    return addZero(dt.getUTCHours())+":"+addZero(dt.getMinutes())+":"+addZero(dt.getSeconds());
   });
 
   openevse.status.elapsed.subscribe(function (val) {


### PR DESCRIPTION
solve issue #107, a time difference (elapsed time) should not be time zone corrected, therefore change getHours (which applies time zone correction) to getUTCHours (which applies no correction). Minutes and seconds are not affected.