### PR TITLE
Fix for setting the hostname. 

### DIFF
--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -115,8 +115,8 @@ startClient()
   // DEBUG.print(" epass:");
   // DEBUG.println(epass.c_str());
 
-  WiFi.hostname(esp_hostname);
   WiFi.begin(esid.c_str(), epass.c_str());
+  WiFi.hostname(esp_hostname);
   WiFi.enableSTA(true);
 }
 


### PR DESCRIPTION
WiFi.hostname must be called after WiFi.begin. Fixes #136 