### PR TITLE
Non volatile set current RAPI command

### DIFF
--- a/src/divert.cpp
+++ b/src/divert.cpp
@@ -178,7 +178,7 @@ void divert_update_state()
       {
         // Set charge rate via RAPI
         bool chargeRateSet = false;
-        // Try and set with new API (and don't save the charge rate in EEPROM)
+        // Try and set current with new API with volatile flag (don't save the current rate to EEPROM)
         if(0 == rapiSender.sendCmd(String(F("$SC ")) + String(charge_rate) + String(F(" V")))) {
           chargeRateSet = true;
         } else if(0 == rapiSender.sendCmd(String(F("$SC ")) + String(charge_rate))) {

--- a/src/divert.cpp
+++ b/src/divert.cpp
@@ -179,7 +179,7 @@ void divert_update_state()
         // Set charge rate via RAPI
         bool chargeRateSet = false;
         // Try and set with new API (and don't save the charge rate in EEPROM)
-        if(0 == rapiSender.sendCmd(String(F("$SC ")) + String(charge_rate) + String(F(" 1")))) {
+        if(0 == rapiSender.sendCmd(String(F("$SC ")) + String(charge_rate) + String(F(" V")))) {
           chargeRateSet = true;
         } else if(0 == rapiSender.sendCmd(String(F("$SC ")) + String(charge_rate))) {
           // Fallback to old API


### PR DESCRIPTION
Use correct RAPI command to set current in a volatile  way (i.e don't save to EEPROM) e.g:

`$SC XX V`

Where XX is the current in Amps

Actually any third argument will actually donate volatile, however using `V` is consistent with the documentation for the non-volatile flag. 

See open_evse commit: https://github.com/lincomatic/open_evse/commit/18971508e02d6228da2c103688f4809cd7240ae3

and changelog:

V4.10.2 onwards

```
20171010 SCL	
- $SC remove bad code (*tokens[2] = 'N') ( should have been ==, not =)..
	was working properly, anyway, but didn't care what character was
	specified. just remove the clause altogether, and allow any 3rd
	arg to make current capacity volatile
- change $SC doc to [V] (volatile) instead of [N] for not saving to EEPROM 
```