### PR TITLE
RFC: OpenEVSE simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ full-upload.sh
 *.pyc
 .cache
 .vscode/launch.json
+
+# Simulator
+node_modules
+package-lock.json

--- a/simulator/.eslintrc.json
+++ b/simulator/.eslintrc.json
@@ -1,0 +1,31 @@
+{
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "indent": [
+      "error",
+      2
+    ],
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "no-console": [
+      "error",
+      {
+        "allow": [
+          "log",
+          "warn",
+          "error"
+        ]
+      }
+    ]
+  }
+}

--- a/simulator/app.js
+++ b/simulator/app.js
@@ -82,7 +82,7 @@ let args = minimist(process.argv.slice(2), {
 });
 
 if(args.help) {
-  console.log("OpenOVSE WiFi Simulator");
+  console.log("OpenEVSE WiFi Simulator");
   return 0;
 }
 

--- a/simulator/app.js
+++ b/simulator/app.js
@@ -1,0 +1,89 @@
+/* jslint node: true, esversion: 6 */
+"use strict";
+
+const ws = require("ws");
+const express = require("express");
+const http = require("http");
+const path = require("path");
+const bodyParser = require("body-parser");
+
+const app = express();
+
+//
+// Create HTTP server by ourselves.
+//
+
+const port = 80;
+
+const server = http.createServer(app);
+
+const wss = new ws.Server({
+  server: server,
+  path: "/ws"
+});
+
+wss.on("connection", function connection(ws) {
+  ws.on("message", function incoming(message) {
+    console.log("received: %s", message);
+  });
+
+  ws.send("something");
+});
+
+// Setup the static content
+app.use(express.static(path.join(__dirname, "../src/data"), { index: "home.htm" }));
+
+// Setup the API endpoints
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+
+app.get("/config", function (req, res) {
+  res.json({ "firmware": "-", "protocol": "-", "espflash": 4194304, "version": "2.5.2.dev", "diodet": 0, "gfcit": 1, "groundt": 1, "relayt": 0, "ventt": 0, "tempt": 0, "service": 2, "scale": 220, "offset": 0, "ssid": "wibble_ext", "pass": "___DUMMY_PASSWORD___", "emoncms_enabled": false, "emoncms_server": "data.openevse.com/emoncms", "emoncms_node": "openevse", "emoncms_apikey": "", "emoncms_fingerprint": "7D:82:15:BE:D7:BC:72:58:87:7D:8E:40:D4:80:BA:1A:9F:8B:8D:DA", "mqtt_enabled": true, "mqtt_server": "home.lan", "mqtt_topic": "openevse", "mqtt_user": "emonpi", "mqtt_pass": "___DUMMY_PASSWORD___", "mqtt_solar": "", "mqtt_grid_ie": "emon/test/grid_ie", "www_username": "", "www_password": "", "ohm_enabled": false });
+});
+app.get("/status", function (req, res) {
+  res.json({"mode":"STA","wifi_client_connected":1,"srssi":(-40 - Math.floor(Math.random() * 20)),"ipaddress":"172.16.0.191","emoncms_connected":0,"packets_sent":0,"packets_success":0,"mqtt_connected":1,"ohm_hour":"NotConnected","free_heap":20816,"comm_sent":1077,"comm_success":1075,"amp":0,"pilot":20,"temp1":247,"temp2":0,"temp3":230,"state":3,"elapsed":1079034,"wattsec":0,"watthour":54,"gfcicount":0,"nogndcount":12,"stuckcount":0,"divertmode":1});
+});
+app.get("/update", function (req, res) {
+  res.send("<html><form method='POST' action='/update' enctype='multipart/form-data'><input type='file' name='firmware'> <input type='submit' value='Update'></form></html>");
+});
+app.get("/r", function (req, res) {
+  var rapi = {
+    "$GT": "$OK 18 0 25 23 54 27^1B",
+    "$GE": "$OK 20 0229^2B",
+    "$GC": "$OK 10 80^29",
+    "$G3": "$OK 0^30",
+    "$GH": "$OK 0^30",
+    "$GO": "$OK 650 650^20",
+    "$GD": "$OK 0 0 0 0^20"
+  };
+
+  var cmd = req.query.rapi;
+
+  switch(cmd)
+  {
+  case "$GT":
+    var date = new Date();
+    var time = [
+      date.getFullYear() % 100,
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds()
+    ];
+    res.json({"cmd":"$GT","ret":"$OK "+time.join(" ")});
+    return;
+  default:
+    if(rapi.hasOwnProperty(cmd)) {
+      res.json({
+        "cmd": cmd,
+        "ret": rapi[cmd]
+      });
+      return;
+    }
+  }
+
+  res.json({"cmd": cmd, "ret":"$NK"});
+});
+
+app.listen(port, () => console.log("Example app listening on port " + port + "!"));

--- a/simulator/app.js
+++ b/simulator/app.js
@@ -107,6 +107,9 @@ app.get("/status", function (req, res) {
 app.get("/update", function (req, res) {
   res.send("<html><form method='POST' action='/update' enctype='multipart/form-data'><input type='file' name='firmware'> <input type='submit' value='Update'></form></html>");
 });
+app.post("/update", function (req, res) {
+  res.status(500).send("Not implemented");
+});
 app.get("/r", function (req, res) {
   var rapi = {
     "$GT": "$OK 18 0 25 23 54 27^1B",
@@ -149,5 +152,46 @@ app.get("/r", function (req, res) {
 
   res.json({ "cmd": cmd, "ret": "$NK" });
 });
+
+app.get("/savenetwork", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/saveemoncms", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/savemqtt", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/saveadmin", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/saveohmkey", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/reset", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/restart", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/scan", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/apoff", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
+app.get("/divertmode", function (req, res) {
+  res.status(500).send("Not implemented");
+});
+
 
 app.listen(port, () => console.log("Example app listening on port " + port + "!"));

--- a/simulator/app.js
+++ b/simulator/app.js
@@ -1,13 +1,14 @@
 /* jslint node: true, esversion: 6 */
 "use strict";
 
-const ws = require("ws");
+var port = 80;
+
 const express = require("express");
-const http = require("http");
 const path = require("path");
 const bodyParser = require("body-parser");
 
 const app = express();
+const expressWs = require("express-ws")(app);
 
 var config = {
   "firmware": "-",
@@ -72,23 +73,6 @@ var status = {
 //
 // Create HTTP server by ourselves.
 //
-
-const port = 80;
-
-const server = http.createServer(app);
-
-const wss = new ws.Server({
-  server: server,
-  path: "/ws"
-});
-
-wss.on("connection", function connection(ws) {
-  ws.on("message", function incoming(message) {
-    console.log("received: %s", message);
-  });
-
-  ws.send("something");
-});
 
 // Setup the static content
 app.use(express.static(path.join(__dirname, "../src/data"), { index: "home.htm" }));
@@ -193,5 +177,10 @@ app.get("/divertmode", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
+app.ws("/ws", function(ws, req) {
+  ws.on("message", function(msg) {
+    //ws.send(msg);
+  });
+});
 
-app.listen(port, () => console.log("Example app listening on port " + port + "!"));
+app.listen(port, () => console.log("OpenEVSE WiFi Simulator listening on port " + port + "!"));

--- a/simulator/app.js
+++ b/simulator/app.js
@@ -137,31 +137,31 @@ app.get("/r", function (req, res) {
   res.json({ "cmd": cmd, "ret": "$NK" });
 });
 
-app.get("/savenetwork", function (req, res) {
+app.post("/savenetwork", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
-app.get("/saveemoncms", function (req, res) {
+app.post("/saveemoncms", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
-app.get("/savemqtt", function (req, res) {
+app.post("/savemqtt", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
-app.get("/saveadmin", function (req, res) {
+app.post("/saveadmin", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
-app.get("/saveohmkey", function (req, res) {
+app.post("/saveohmkey", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
-app.get("/reset", function (req, res) {
+app.post("/reset", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
-app.get("/restart", function (req, res) {
+app.post("/restart", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
@@ -169,11 +169,11 @@ app.get("/scan", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
-app.get("/apoff", function (req, res) {
+app.post("/apoff", function (req, res) {
   res.status(500).send("Not implemented");
 });
 
-app.get("/divertmode", function (req, res) {
+app.post("/divertmode", function (req, res) {
   res.status(500).send("Not implemented");
 });
 

--- a/simulator/app.js
+++ b/simulator/app.js
@@ -1,14 +1,12 @@
 /* jslint node: true, esversion: 6 */
 "use strict";
 
-var port = 80;
 
 const express = require("express");
 const path = require("path");
 const bodyParser = require("body-parser");
+const minimist = require("minimist");
 
-const app = express();
-const expressWs = require("express-ws")(app);
 
 var config = {
   "firmware": "-",
@@ -42,6 +40,7 @@ var config = {
   "www_password": "",
   "ohm_enabled": false
 };
+
 var status = {
   "mode": "STA",
   "wifi_client_connected": 1,
@@ -69,6 +68,33 @@ var status = {
   "stuckcount": 0,
   "divertmode": 1
 };
+
+let args = minimist(process.argv.slice(2), {
+  alias: {
+    h: "help",
+    v: "version"
+  },
+  default: {
+    help: false,
+    version: false,
+    port: 3000
+  },
+});
+
+if(args.help) {
+  console.log("OpenOVSE WiFi Simulator");
+  return 0;
+}
+
+if(args.version) {
+  console.log(config.version);
+  return 0;
+}
+
+var port = args.port;
+
+const app = express();
+const expressWs = require("express-ws")(app);
 
 //
 // Create HTTP server by ourselves.

--- a/simulator/example-openevse-apache.conf
+++ b/simulator/example-openevse-apache.conf
@@ -1,9 +1,9 @@
 <VirtualHost *:80>
-        ServerName openovse.bigjungle.net
+        ServerName openevse.bigjungle.net
         DocumentRoot /home/jeremy/openevse/src/data
 
-        ErrorLog ${APACHE_LOG_DIR}/openovse_error.log
-        CustomLog ${APACHE_LOG_DIR}/openovse_access.log combined
+        ErrorLog ${APACHE_LOG_DIR}/openevse_error.log
+        CustomLog ${APACHE_LOG_DIR}/openevse_access.log combined
 
         ProxyRequests Off
         ProxyPass "/ws"  "ws://localhost:3000/ws"

--- a/simulator/example-openevse-apache.conf
+++ b/simulator/example-openevse-apache.conf
@@ -1,0 +1,31 @@
+<VirtualHost *:80>
+        ServerName openovse.bigjungle.net
+        DocumentRoot /home/jeremy/openevse/src/data
+
+        ErrorLog ${APACHE_LOG_DIR}/openovse_error.log
+        CustomLog ${APACHE_LOG_DIR}/openovse_access.log combined
+
+        ProxyRequests Off
+        ProxyPass "/ws"  "ws://localhost:3000/ws"
+        ProxyPassReverse "/ws"  "ws://localhost:3000/ws"
+
+        RewriteEngine on
+        LogLevel alert rewrite:trace6
+
+        # Redirect web sockets
+        RewriteRule /ws ws://localhost:3000/ws [L,P]
+
+        # Redirect missing files to the ap server
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^([^.?]+)$ http://localhost:3000%{REQUEST_URI} [L,P]
+
+        DirectoryIndex home.htm
+
+</VirtualHost>
+
+<Directory /home/jeremy/openevse/src/data>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+</Directory>

--- a/simulator/package.json
+++ b/simulator/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.16.2",
+    "express-ws": "^3.0.0",
     "ws": "^4.0.0"
   },
   "devDependencies": {

--- a/simulator/package.json
+++ b/simulator/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ws_server",
+  "version": "1.0.0",
+  "description": "Simple emulation of OpenEVSE WiFi WebSocket server",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.16.2",
+    "ws": "^4.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.16.0"
+  }
+}

--- a/simulator/package.json
+++ b/simulator/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "express": "^4.16.2",
     "express-ws": "^3.0.0",
+    "minimist": "^1.2.0",
     "ws": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Here is the initial version of my OpenEVSE WiFi Simulator. 

This is a Node.JS application that can be run from the sauce tree to provide a local server for testing the UI code against, or can be used standalone for demos (#116). It could even become the base of an Orange Pi version as indicated in comments to #116.

I need to do some documentation and systemd script, but basically done. In short,

Install (assumes you already have Node.js installed)
```
cd simulator
npm install
```

Run
```
node app.js --port 80
```

Note: currently the server has to be run on port 80 as the UI code doesn't currently handle running on a different port.
