### PR TITLE
Adhoc Mode crash fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,18 +56,13 @@ $RECYCLE.BIN/
 .piolibdeps
 .clang_complete
 .gcc-flags.json
-.vscode
-.vscode/browse.vc.db*
 
 full-upload.sh
 *.gch
-.vscode/browse.vc.db*
-.vscode/c_cpp_properties.json
 
 # Python code
 *.pyc
 .cache
-.vscode/launch.json
 
 # Simulator
 node_modules
@@ -75,3 +70,10 @@ package-lock.json
 
 .vagrant
 ubuntu-xenial-16.04-cloudimg-console.log
+
+# VSCode stuff
+.vscode
+.vscode/browse.vc.db*
+.vscode/c_cpp_properties.json
+.vscode/*.db
+.vscode/launch.json

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,8 @@ lib_deps = PubSubClient@2.6, ESP Async WebServer@1.1.1, ESPAsyncTCP@1.1.3
 extra_scripts = scripts/extra_script.py
 debug_flags = -DENABLE_DEBUG -DENABLE_PROFILE -DDEBUG_PORT=Serial1
 ota_flags = -DENABLE_OTA -DWIFI_LED=0
-build_flags = -DENABLE_ASYNC_WIFI_SCAN
+build_flags =
+# -DENABLE_ASYNC_WIFI_SCAN
 
 # specify exact Arduino ESP SDK version, requires platformio 3.5+ (curently dev version)
 # http://docs.platformio.org/en/latest/projectconf/section_env_general.html#platform

--- a/scripts/extra_script.py
+++ b/scripts/extra_script.py
@@ -159,7 +159,7 @@ def make_static(env, target, source):
           out_files.append(file)
 
     # Sort files to make sure the order is constant
-    out_files = sorted(out_files);
+    out_files = sorted(out_files)
 
     # include the files
     for out_file in out_files:

--- a/simulator/app.js
+++ b/simulator/app.js
@@ -206,7 +206,9 @@ app.post("/restart", function (req, res) {
 
 app.get("/scan", function (req, res) {
   res.header("Cache-Control", "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0");
-  res.status(500).send("Not implemented");
+  setTimeout(function () {
+    res.json([{"rssi":-51,"ssid":"wibble_ext","bssid":"C4:04:15:5A:45:DE","channel":11,"secure":4,"hidden":false},{"rssi":-45,"ssid":"esplug_10560510","bssid":"1A:FE:34:A1:23:FE","channel":11,"secure":7,"hidden":false},{"rssi":-85,"ssid":"BTWifi-with-FON","bssid":"02:FE:F4:32:F1:08","channel":6,"secure":7,"hidden":false},{"rssi":-87,"ssid":"BTWifi-X","bssid":"22:FE:F4:32:F1:08","channel":6,"secure":7,"hidden":false},{"rssi":-75,"ssid":"wibble","bssid":"6C:B0:CE:20:7C:3A","channel":6,"secure":4,"hidden":false},{"rssi":-89,"ssid":"BTHub3-ZWCW","bssid":"00:FE:F4:32:F1:08","channel":6,"secure":8,"hidden":false}]);
+  }, 5000);
 });
 
 app.post("/apoff", function (req, res) {

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,6 +1,8 @@
 #ifndef __DEBUG_H
 #define __DEBUG_H
 
+#include <core_version.h>
+
 //#define ENABLE_DEBUG
 //#define DEBUG_PORT Serial
 
@@ -16,7 +18,7 @@
 
 #define DEBUG_BEGIN(speed)  DEBUG_PORT.begin(speed)
 
-#ifdef ARDUINO_ESP8266_RELEASE_2_3_0
+#ifdef ARDUINO_ESP8266_RELEASE_2_4_0
 // Serial.printf_P needs Git version of Arduino Core
 #define DBUGF(format, ...)  DEBUG_PORT.printf_P(PSTR(format "\n"), ##__VA_ARGS__)
 #else

--- a/src/web_server_static.cpp
+++ b/src/web_server_static.cpp
@@ -125,15 +125,15 @@ size_t StaticFileResponse::writeData(AsyncWebServerRequest *request)
 {
   size_t space = request->client()->space();
 
-  //DBUGF("%p: StaticFileResponse::write: %s %d %d@%p", request,
-  //  RESPONSE_SETUP == _state ? "RESPONSE_SETUP" :
-  //  RESPONSE_HEADERS == _state ? "RESPONSE_HEADERS" :
-  //  RESPONSE_CONTENT == _state ? "RESPONSE_CONTENT" :
-  //  RESPONSE_WAIT_ACK == _state ? "RESPONSE_WAIT_ACK" :
-  //  RESPONSE_END == _state ? "RESPONSE_END" :
-  //  RESPONSE_FAILED == _state ? "RESPONSE_FAILED" :
-  //  "UNKNOWN",
-  //  space, length, ptr);
+  DBUGF("%p: StaticFileResponse::write: %s %d %d@%p, free %d", request,
+    RESPONSE_SETUP == _state ? "RESPONSE_SETUP" :
+    RESPONSE_HEADERS == _state ? "RESPONSE_HEADERS" :
+    RESPONSE_CONTENT == _state ? "RESPONSE_CONTENT" :
+    RESPONSE_WAIT_ACK == _state ? "RESPONSE_WAIT_ACK" :
+    RESPONSE_END == _state ? "RESPONSE_END" :
+    RESPONSE_FAILED == _state ? "RESPONSE_FAILED" :
+    "UNKNOWN",
+    space, length, ptr, ESP.getFreeHeap());
 
   if(length > 0 && space > 0)
   {


### PR DESCRIPTION
This change 'fixes' #142. The underlying change that 'broke' the AP mode was enabling the Async WiFi scan. This has the inadvertent effect of tying up an additional 4K of RAM because the web request is hanging around for a longer period.

This reverts that change and goes back to the polling method, not quite as nice but at least it works.

Will revisit the ASync WiFi scan if/when ASyncWebserver is a bit more memory friendly.

I also enabled a small optimisation for keeping debug messages in flash now the support for this is stable.