### PR TITLE
Added cache headers to stop IE caching the status

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -110,6 +110,8 @@ bool requestPreProcess(AsyncWebServerRequest *request, AsyncResponseStream *&res
     response->addHeader(F("Access-Control-Allow-Origin"), F("*"));
   }
 
+  response->addHeader(F("Cache-Control"), F("no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0"));
+
   return true;
 }
 


### PR DESCRIPTION
IE was caching the /status so the new state was not being received. This change adds cache control headers to stop the browsers caching the data (probably should have been there anyway). Improves on #166 although websockets are still not working so the updates are not immediate, but at least with this change the updates still get through.
 