### PR TITLE
Post total wh to Emoncms instead of watt-seconds

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -93,7 +93,7 @@ create_rapi_json() {
   if (volt > 0) {
     data += "volt:" + String(volt) + ",";
   }
-  data += "wh:" + String(wattsec) + ",";
+  data += "wh:" + String(watthour_total) + ",";
   data += "temp1:" + String(temp1) + ",";
   data += "temp2:" + String(temp2) + ",";
   data += "temp3:" + String(temp3) + ",";


### PR DESCRIPTION
Currently the OpenEVSE posts watt-seconds to Emoncms. IMO this is particular unuseful and probably my mistake! 

I propose changing to post total accumulative wh 

This Input can then have a 0.001 scale applied in Emoncms input processing and logged to a Feed using wh_accumlator Emoncms input process. This will ensure that even when the OpenEVSE EEPROM is erased and the total wh is lost Emoncms will preserve the value i.e wh_acculoator Emoncms feeds cannot go down, only up! 

Here is a device template for the new device module (now live on Emoncm.org and emonPi) for the OpenEVSE to automate logging inputs correctly to feeds:

https://github.com/emoncms/device/blob/master/data/OpenEnergyMonitor/openevse.json